### PR TITLE
Init Call Support

### DIFF
--- a/host.go
+++ b/host.go
@@ -2,26 +2,28 @@ package modules
 
 type Host struct {
 	api     *API
-	workers []IWorker
+	modules []*Module
 }
 
 func (host *Host) Run() {
 	var forever chan struct{}
 
+	for _, module := range host.modules {
+
+		module.invokeInitCalls()
+
+		go module.startWorkers()
+	}
+
 	if host.api != nil {
 		go host.api.run()
 	}
-
-	for _, worker := range host.workers {
-		go worker.Run()
-	}
-
 	<-forever
 }
 
-func NewHost(api *API, workers []IWorker) *Host {
+func NewHost(api *API, modules []*Module) *Host {
 	return &Host{
 		api:     api,
-		workers: workers,
+		modules: modules,
 	}
 }

--- a/host.go
+++ b/host.go
@@ -6,19 +6,25 @@ type Host struct {
 }
 
 func (host *Host) Run() {
+	host.invokeInitCalls()
+
 	var forever chan struct{}
 
 	for _, module := range host.modules {
-
-		module.invokeInitCalls()
-
 		go module.startWorkers()
 	}
 
 	if host.api != nil {
 		go host.api.run()
 	}
+
 	<-forever
+}
+
+func (host *Host) invokeInitCalls() {
+	for _, module := range host.modules {
+		module.invokeInitCalls()
+	}
 }
 
 func NewHost(api *API, modules []*Module) *Host {

--- a/host_builder.go
+++ b/host_builder.go
@@ -25,20 +25,19 @@ func (builder *HostBuilder) AddModule(configure ConfigureModule) {
 func (builder *HostBuilder) Build() *Host {
 	api := builder.buildAPI()
 
-	workers := newWorkers()
+	modules := make([]*Module, 0)
 
 	for _, config := range builder.configurations {
-		config.validate()
+		module := config.build()
 
 		if api != nil {
-			config.registerControllers(api)
+			module.registerControllers(api)
 		}
 
-		moduleWorkers := config.createWorkers()
-		workers = append(workers, moduleWorkers...)
+		modules = append(modules, module)
 	}
 
-	host := NewHost(api, workers)
+	host := NewHost(api, modules)
 	return host
 }
 

--- a/module.go
+++ b/module.go
@@ -1,0 +1,55 @@
+package modules
+
+import (
+	"go.uber.org/dig"
+)
+
+type Module struct {
+	name        string
+	workers     []IWorker
+	controllers []IController
+	initCalls   []InitCall
+	container   *dig.Container
+}
+
+func (module *Module) appendControler(controller IController) {
+	module.controllers = append(module.controllers, controller)
+}
+
+func (module *Module) appendWorker(worker IWorker) {
+	module.workers = append(module.workers, worker)
+}
+
+func (module *Module) appendInitCall(initCall InitCall) {
+	module.initCalls = append(module.initCalls, initCall)
+}
+
+func (module *Module) registerControllers(api *API) {
+	group := api.rootGroup.Group(module.name)
+
+	for _, controller := range module.controllers {
+		controller.Register(group)
+	}
+}
+
+func (module *Module) startWorkers() {
+	for _, worker := range module.workers {
+		go worker.Run()
+	}
+}
+
+func (module *Module) invokeInitCalls() {
+	for _, initCall := range module.initCalls {
+		initCall(module.container)
+	}
+}
+
+func newModule(name string, container *dig.Container) *Module {
+	return &Module{
+		name:        name,
+		container:   container,
+		workers:     make([]IWorker, 0),
+		controllers: make([]IController, 0),
+		initCalls:   make([]InitCall, 0),
+	}
+}


### PR DESCRIPTION
The motivation behind init calls is to support modules to invoke individual functions before the application has started.
The `InitCall` function receives the `*dig.Container` instance for that module, which allows invoking injected dependencies using: 

```go
container.Invoke(func(...) { })
```

## Workflow

The `HostBuilder` is used to configure the **API** and all **service modules**, when calling `hostBuilder.Build()` it creates the `Host` instance. When `host.Run()` is invoked, the package iterates through all configured modules to invoke `InitCall` functions. Then the `Host` creates a _forever channel_, and starts all `Workers` and the `API`.

## Usage

```go
package foomodule

import modules "github.com/mitz-it/golang-modules"

func FooModule(config *modules.ModuleConfiguration) {
  config.WithName("/foos")
  di, container := NewDependencyInjectionContainer()
  di.Setup()
  config.WithDIContainer(container)
  config.AddController(NewFoosController)
  config.AddWorker(NewFooWorker)
  config.SetupInitCall(migrateDatabase)
}

func migrateDatabase(container *dig.Container) {
    err := container.Invoke(func(db DatabaseProvider) {
        if connection, err := db.Connect(); err == nil {
            connection.Migrate()
	} else {
	    panic(err)
	}
    })
    if err != nil {
        panic(err)
   }
}
```

### Recommended for:
- Checking if external services (databases, brokers, etc...) are reachable ✅ 
- Applying migrations ✅ 

### Not recommended for:
- Database seeding ❌ 
- Invoking business rules ❌ 