### PR TITLE
feat: support nameless modules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+<!-- Edit the version -->
+
+# Version X.X.X :beaver:
+
+<!-- Please summarize the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
+
+## Checklist :white_check_mark:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+## Changelog :label:
+
+<!-- Please fill out the changes applicable to your PR, and remove the irrelevant ones. -->
+
+### Fixes :hammer_and_wrench:
+
+- [x] Fixing typo at ...
+
+### Features :building_construction:
+
+- [x] Adding support for ...
+
+### Breaking Changes :bomb:
+
+- [x] Removing support for ...
+
+### Documentation :page_facing_up:
+
+- [x] Adding an example of ...
+
+## How Has This Been Tested? :test_tube:
+
+<!-- Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration -->
+
+- Test scenario 1:
+
+  Explanation of how this was tested.
+
+- Test scenario 2:
+
+  Explanation of how this was tested.

--- a/.github/workflows/pr_linter.yml
+++ b/.github/workflows/pr_linter.yml
@@ -1,0 +1,30 @@
+name: Pull Request Lint
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    name: PR Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check commits
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          wip: true
+          types: |
+            fix
+            feat
+            refactor
+            test
+            chore
+            WIP
+            build
+            ci

--- a/README.md
+++ b/README.md
@@ -108,8 +108,6 @@ func NewDependencyInjectionContainer() (modules.IDependencyInjectionContainer, *
 }
 ```
 
-
-
 ## Controllers
 
 Controllers are a group of endpoints for the same **resource** or **collection**. To define a **controller** you need to implement the `IController` interface by adding the `Register(*gin.RouterGroup)` method to the **controller struct** and,
@@ -217,6 +215,10 @@ func PrivateGroupsModule(config *modules.ModuleConfiguration) {
   config.AddWorker(NewPrivateGroupRequestsWorker)
 }
 ```
+
+:warning: **FOR VERSIONS >= 1.13.0, MODULE NAMES ARE OPTIONAL** :warning:
+
+When a module is nameless, all endpoints are added to the root `*gin.RouterGroup`, which default path is `/api`.
 
 Register the `PrivateGroupsModule` function using the `HostBuilder` instance:
 

--- a/module.go
+++ b/module.go
@@ -1,6 +1,7 @@
 package modules
 
 import (
+	"github.com/gin-gonic/gin"
 	"go.uber.org/dig"
 )
 
@@ -25,7 +26,13 @@ func (module *Module) appendInitCall(initCall InitCall) {
 }
 
 func (module *Module) registerControllers(api *API) {
-	group := api.rootGroup.Group(module.name)
+	var group *gin.RouterGroup
+
+	if module.name != "" {
+		group = api.rootGroup.Group(module.name)
+	} else {
+		group = api.rootGroup
+	}
 
 	for _, controller := range module.controllers {
 		controller.Register(group)

--- a/module_builder.go
+++ b/module_builder.go
@@ -67,10 +67,11 @@ func (config *ModuleConfiguration) build() *Module {
 }
 
 func newModuleConfiguration() *ModuleConfiguration {
-	config := new(ModuleConfiguration)
-	config.name = ""
-	config.controllersFunc = make([]ControllerConstructorFunc, 0)
-	config.workersFunc = make([]WorkerConstructorFunc, 0)
-	config.initCalls = make([]InitCall, 0)
+	config := &ModuleConfiguration{
+		name:            "",
+		controllersFunc: make([]ControllerConstructorFunc, 0),
+		workersFunc:     make([]WorkerConstructorFunc, 0),
+		initCalls:       make([]InitCall, 0),
+	}
 	return config
 }

--- a/module_builder.go
+++ b/module_builder.go
@@ -39,11 +39,6 @@ func (config *ModuleConfiguration) SetupInitCall(initCall InitCall) {
 }
 
 func (config *ModuleConfiguration) validate() {
-	if config.name == "" {
-		err := errors.New("module name cannot be empyt")
-		panic(err)
-	}
-
 	if config.container == nil {
 		err := errors.New("di container cannot be nil")
 		panic(err)
@@ -73,6 +68,7 @@ func (config *ModuleConfiguration) build() *Module {
 
 func newModuleConfiguration() *ModuleConfiguration {
 	config := new(ModuleConfiguration)
+	config.name = ""
 	config.controllersFunc = make([]ControllerConstructorFunc, 0)
 	config.workersFunc = make([]WorkerConstructorFunc, 0)
 	config.initCalls = make([]InitCall, 0)


### PR DESCRIPTION
<!-- Edit the version -->

# Version 1.13.0 :beaver:

Adding support to create nameless modules. Nameless modules won't have their name added to the root `*gin.RouterGroup`.

E.g: When a module is named "/foo", all controllers within this module will be prefixed with "/api/foo", having their endpoints added before that.
With nameless modules, all controller endpoints are appended to the "/api" by default.

## Checklist :white_check_mark:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~New and existing unit tests pass locally with my changes~~
- [x] Any dependent changes have been merged and published in downstream modules

## Changelog :label:

<!-- Please fill out the changes applicable to your PR, and remove the irrelevant ones. -->

### Features :building_construction:

- [x] Adding support for nameless modules, when a module is nameless all endpoints from all the module controllers will be appended to the root `*gin.RouterGroup`, which the default path is `/api`.

### Documentation :page_facing_up:

- [x] Adding disclaimer, and explanation of the impact that nameless modules will have on applications.

## How Has This Been Tested? :test_tube:

<!-- Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration -->

- Test scenario 1:

  An existent microservice, without `golang-modules` installed, was used to test this feature. In this microservice, we had two hard-coded modules, each with a single controller, each with a single endpoint registered into gin's root `*gin.RouterGroup` ("/api"). I've installed the `golang-modules` package and added the module configuration functions. Both modules were configured as nameless modules. The API worked as expected, keeping the endpoints attached to the `/api`. This is important, so we won't break any existent code that calls our API.